### PR TITLE
Fixes to build package under CMake

### DIFF
--- a/dist-impl.sh
+++ b/dist-impl.sh
@@ -36,6 +36,7 @@ function dist_prepare() {
     _GC_WIN_REPOS_UDIR=`unix_path $GC_WIN_REPOS_DIR`
     _REPOS_UDIR=`unix_path $REPOS_DIR`
     _BUILD_UDIR=`unix_path $BUILD_DIR`
+    _GNUCASH_CMAKE_BUILD_UDIR=`unix_path $GNUCASH_CMAKE_BUILD_DIR`
     _DIST_UDIR=`unix_path $DIST_DIR`
     _MINGW_UDIR=`unix_path $MINGW_DIR`
     _INSTALL_UDIR=`unix_path $INSTALL_DIR`
@@ -260,6 +261,9 @@ function dist_gnucash() {
     AQBANKING_VERSION_H=${_AQBANKING_UDIR}/include/aqbanking5/aqbanking/version.h
     GWENHYWFAR_VERSION_H=${_GWENHYWFAR_UDIR}/include/gwenhywfar4/gwenhywfar/version.h
     GNUCASH_CONFIG_H=${_BUILD_UDIR}/config.h
+    if [ "$WITH_CMAKE" == "yes" ]; then
+        GNUCASH_CONFIG_H=${_GNUCASH_CMAKE_BUILD_UDIR}/src/config.h
+    fi
 
     _AQBANKING_SO_EFFECTIVE=$(awk '/AQBANKING_SO_EFFECTIVE / { print $3 }' ${AQBANKING_VERSION_H} )
     _GWENHYWFAR_SO_EFFECTIVE=$(awk '/GWENHYWFAR_SO_EFFECTIVE / { print $3 }' ${GWENHYWFAR_VERSION_H} )

--- a/dist-impl.sh
+++ b/dist-impl.sh
@@ -245,7 +245,12 @@ function dist_gnucash() {
     cp -a $_INSTALL_UDIR/bin/* $_DIST_UDIR/bin
     mkdir -p $_DIST_UDIR/etc/gnucash
     cp -a $_INSTALL_UDIR/etc/gnucash/* $_DIST_UDIR/etc/gnucash
-    cp -a $_INSTALL_UDIR/lib/lib*.la $_DIST_UDIR/bin
+
+    # For CMake builds, there are no lib*.la files, so skip. 
+    if [ "$WITH_CMAKE" != "yes" ]; then
+        cp -a $_INSTALL_UDIR/lib/lib*.la $_DIST_UDIR/bin
+    fi 
+
     mkdir -p $_DIST_UDIR/share
     cp -a $_INSTALL_UDIR/share/{doc,gnucash,locale,glib-2.0} $_DIST_UDIR/share
     cp -a $_GC_WIN_REPOS_UDIR/extra_dist/{getperl.vbs,gnc-path-check,install-fq-mods.cmd} $_DIST_UDIR/bin
@@ -280,11 +285,15 @@ function dist_gnucash() {
 }
 
 function dist_finish() {
-    # Strip redirections in distributed libtool .la files
-    for file in $_DIST_UDIR/bin/*.la; do
-        cat $file | sed 's,^libdir=,#libdir=,' > $file.new
-        mv $file.new $file
-    done
+    if [ "$WITH_CMAKE" != "yes" ]; then
+        # Strip redirections in distributed libtool .la files.
+	# Skip this for CMake builds, which don't generate *.la files.
+
+        for file in $_DIST_UDIR/bin/*.la; do
+            cat $file | sed 's,^libdir=,#libdir=,' > $file.new
+            mv $file.new $file
+        done
+    fi;
 
     echo "Now running the Inno Setup Compiler for creating the setup.exe"
     ${_INNO_UDIR}/iscc //Q ${_GNUCASH_UDIR}/gnucash.iss

--- a/install-impl.sh
+++ b/install-impl.sh
@@ -1330,6 +1330,13 @@ function inst_gnucash_using_cmake() {
     _LIBDBI_DRIVERS_UDIR=`unix_path ${LIBDBI_DRIVERS_DIR}`
     
     mkdir -p $_BUILD_UDIR
+
+    # Remove existing INSTALL_UDIR
+    if [ -x $_INSTALL_UDIR ]; then
+        echo Removing previous inst dir $_INSTALL_UDIR ...
+        rm -rf "$_INSTALL_UDIR"
+    fi;
+
     add_to_env $_INSTALL_UDIR/bin PATH
 
     if [ "$BUILD_FROM_TARBALL" != "yes" ]; then


### PR DESCRIPTION
  * install-impl.sh: remove existing $_INSTALL_UDIR directory (e.g.
                  /c/gcdev/gnucash/inst)

  * dist-impl.sh: when using CMake, skip stuff that deals with *.la files,
                  which are autotools specific.