### PR TITLE
Finance::Quote installation scripts updated

### DIFF
--- a/extra_dist/getperl.vbs
+++ b/extra_dist/getperl.vbs
@@ -11,7 +11,8 @@ Dim tempFolder: tempFolder = fso.GetSpecialFolder(TemporaryFolder)
 strHDLocation = Wscript.Arguments.Item(0)
 
 ' Set your settings
-    strFileURL    = "http://strawberryperl.com/download/5.18.2.2/strawberry-perl-5.18.2.2-32bit.msi"
+    ' link can be updated from http://strawberryperl.com/
+    strFileURL    = "http://strawberryperl.com/download/5.26.2.1/strawberry-perl-5.26.2.1-32bit.msi"
 
     Wscript.Echo "   copying " & strFileURL
     Wscript.Echo "   to "  & strHDLocation

--- a/extra_dist/install-fq-mods.cmd
+++ b/extra_dist/install-fq-mods.cmd
@@ -107,6 +107,22 @@ if %errorlevel% neq 0 goto error
 
 REM ----------------------------------------------------------------------------
 echo.
+echo * Check environment variable ALPHAVANTAGE_API_KEY
+echo.
+
+echo.  ***
+echo.  *** You need an API key (from https://www.alphavantage.co)
+echo.  ***   to run the Perl module Finance::Quote.
+echo.  ***
+echo.  *** Make it available to GnuCash by
+if not [%ALPHAVANTAGE_API_KEY%] == [] set "done=(done) "
+echo.  ***    - setting the environment variable ALPHAVANTAGE_API_KEY %done%or
+echo.  ***    - starting GnuCash and adding the Alpha Vantage api key in
+echo.  ***        Edit-^>Preferences-^>Online Quotes
+echo.  ***
+
+REM ----------------------------------------------------------------------------
+echo.
 echo * Run gnc-fq-check
 echo.
 perl -w gnc-fq-check

--- a/extra_dist/install-fq-mods.cmd
+++ b/extra_dist/install-fq-mods.cmd
@@ -116,7 +116,7 @@ REM ----------------------------------------------------------------------------
 echo.
 echo * Run gnc-fq-helper
 echo.
-echo (yahoo "AMZN") | perl -w gnc-fq-helper
+echo (alphavantage "AMZN") | perl -w gnc-fq-helper
 if %errorlevel% neq 0 goto error
 
 REM ----------------------------------------------------------------------------
@@ -134,5 +134,6 @@ echo.
 
 REM ----------------------------------------------------------------------------
 :end
+endlocal
 pause
 


### PR DESCRIPTION
Some minor edits and updates. Please amend as you may find appropriate.

Separately:
1.  Extension `.pl` could be added to the names of the perl scripts.
2. The link to the **helpful** Finance::Quote installation script `install-fq-mods.cmd` does not show up in my Windows Start folder, as there is nothing in there from GnuCash at all (Windows 10, GC 2.6.21).

Please let me know if you want me to file a bug for (2).