### PR TITLE
Update aqbanking/gwenhywfar.

### DIFF
--- a/gnucash.modules
+++ b/gnucash.modules
@@ -146,8 +146,7 @@
 
   <autotools id="gwenhywfar" autogen-sh="configure"
 	     autogenargs="--with-guis='gtk3' --enable-local-install --disable-binreloc --disable-ssl">
-    <branch module="104/gwenhywfar-4.20.1.tar.gz" version="4.20.1" repo="aqbanking" checkoutdir="gwenhywfar-4.20.1">
-      <patch file="gwenhywfar-4.20.1-clean-targets.patch" strip="1"/>
+    <branch module="108/gwenhywfar-4.20.2.tar.gz" version="4.20.2" repo="aqbanking" checkoutdir="gwenhywfar-4.20.2">
     </branch>
     <dependencies>
       <dep package="gcrypt"/>
@@ -175,7 +174,7 @@
 
   <autotools id="aqbanking" autogen-sh="autoreconf" makeargs="-j1"
 	     autogenargs="--enable-local-install">
-    <branch module="105/aqbanking-5.8.1.tar.gz" repo="aqbanking" version="5.8.1" checkoutdir="aqbanking-5.8.1">
+    <branch module="107/aqbanking-5.8.2.tar.gz" repo="aqbanking" version="5.8.2" checkoutdir="aqbanking-5.8.2">
     </branch>
     <dependencies>
       <dep package="gwenhywfar"/>


### PR DESCRIPTION
Needed because gwen 4.20.1 contains a crashing bug, fixed in 4.20.2.