### PR TITLE
Aqb6test

### DIFF
--- a/gnucash.modules
+++ b/gnucash.modules
@@ -146,7 +146,7 @@
 
   <autotools id="gwenhywfar" autogen-sh="configure"
 	     autogenargs="--with-guis='gtk3' --enable-local-install --disable-binreloc --disable-ssl">
-    <branch module="108/gwenhywfar-4.99.15beta.tar.gz" version="4.99.15beta"
+    <branch module="136/gwenhywfar-4.99.15beta.tar.gz" version="4.99.15beta"
             repo="aqbanking" />
     <dependencies>
       <dep package="gcrypt"/>
@@ -174,7 +174,7 @@
 
   <autotools id="aqbanking" autogen-sh="autoreconf" makeargs="-j1"
 	     autogenargs="--enable-local-install">
-    <branch module="107/aqbanking-5.99.30beta.tar.gz" repo="aqbanking" version="5.99.30beta" >
+    <branch module="134/aqbanking-5.99.30beta.tar.gz" repo="aqbanking" version="5.99.30beta" >
     </branch>
     <dependencies>
       <dep package="gwenhywfar"/>

--- a/gnucash.modules
+++ b/gnucash.modules
@@ -146,7 +146,7 @@
 
   <autotools id="gwenhywfar" autogen-sh="configure"
 	     autogenargs="--with-guis='gtk3' --enable-local-install --disable-binreloc --disable-ssl">
-    <branch module="108/gwenhywfar-4.20.2.tar.gz" version="4.20.2"
+    <branch module="108/gwenhywfar-4.99.15beta.tar.gz" version="4.99.15beta"
             repo="aqbanking" />
     <dependencies>
       <dep package="gcrypt"/>
@@ -174,7 +174,7 @@
 
   <autotools id="aqbanking" autogen-sh="autoreconf" makeargs="-j1"
 	     autogenargs="--enable-local-install">
-    <branch module="107/aqbanking-5.8.2.tar.gz" repo="aqbanking" version="5.8.2" >
+    <branch module="107/aqbanking-5.99.30beta.tar.gz" repo="aqbanking" version="5.99.30beta" >
     </branch>
     <dependencies>
       <dep package="gwenhywfar"/>

--- a/gnucash.modules
+++ b/gnucash.modules
@@ -135,8 +135,8 @@
   </autotools>
 
   <autotools id="libchipcard" autogen-sh="configure" autogenargs="--enable-local-install">
-    <branch module="gnucash/Dependencies/libchipcard-5.0.4.tar.gz" version="5.0.4"
-            repo="sourceforge">
+    <branch module="138/libchipcard-5.1.3beta".tar.gz" version="5.1.3beta"
+            repo="aqbanking">
     </branch>
     <dependencies>
       <dep package="gcrypt"/>


### PR DESCRIPTION
Use Betas of Aqbanking 6 in the windows nightlies. This will give ways more testers for both components - AqBanking and GnuCash.

As a side effect it will give some users bank access again.

If there is no stable Aqb6 family release before our next release, revert it.