### PR TITLE
Update xmlsec to 1.2.29

### DIFF
--- a/gnucash.modules
+++ b/gnucash.modules
@@ -166,9 +166,9 @@
   </autotools>
 
   <autotools id="xmlsec" >
-    <branch module="lsh123/xmlsec/archive/xmlsec-1_2_28.tar.gz"
-            repo="github-tar" version="1.2.28"
-            checkoutdir="xmlsec-xmlsec-1_2_28">
+    <branch module="lsh123/xmlsec/archive/xmlsec-1_2_29.tar.gz"
+            repo="github-tar" version="1.2.29"
+            checkoutdir="xmlsec-xmlsec-1_2_29">
         <patch file="xmlsec-make-clean.patch" strip="1"/>
     </branch>
     <dependencies>


### PR DESCRIPTION
Reason: use the same version as in flatpak