### PR TITLE
Update to aqbanking-6.2.2, gwenhywfar-5.4.0

### DIFF
--- a/gnucash.modules
+++ b/gnucash.modules
@@ -143,7 +143,7 @@
 
   <autotools id="gwenhywfar" autogen-sh="configure"
              autogenargs="--with-guis='gtk3' --enable-local-install --disable-binreloc --disable-ssl PKG_CONFIG='pkg-config --dont-define-prefix'">
-    <branch module="319/gwenhywfar-5.3.0.tar.gz" version="5.3.0"
+    <branch module="331/gwenhywfar-5.4.0.tar.gz" version="5.4.0"
             repo="aqbanking">
     </branch>
     <dependencies>
@@ -174,7 +174,7 @@
 
   <autotools id="aqbanking" autogen-sh="autoreconf" makeargs="-j1"
 	     autogenargs="--enable-local-install">
-    <branch module="328/aqbanking-6.2.1.tar.gz" repo="aqbanking" version="6.2.1" >
+    <branch module="334/aqbanking-6.2.2.tar.gz" repo="aqbanking" version="6.2.2" >
     </branch>
     <dependencies>
       <dep package="gwenhywfar"/>


### PR DESCRIPTION
AqBanking: Improvements in AqFinTS, AqHBCI, AqOfxConnect.
Gwenhywfar requires libxml2 now.