### PR TITLE
update libofx to 0.9.15

### DIFF
--- a/gnucash.modules
+++ b/gnucash.modules
@@ -215,8 +215,8 @@
   </autotools>
 
   <autotools id="libofx" autogen-sh='autoreconf'>
-    <branch repo="sourceforge" module="libofx/libofx-0.9.14.tar.gz"
-	    version="0.9.14"/>
+    <branch repo="sourceforge" module="libofx/libofx-0.9.15.tar.gz"
+	    version="0.9.15"/>
     <dependencies>
       <dep package="OpenSP"/>
     </dependencies>


### PR DESCRIPTION
@jralls can you test also its usage? 
I will hold back the corresponding flatpak commit, where I also.did not see an md5 or sha-sum at github. OTOH my flatpak build did not abort for a wrong sha256sum.