### PR TITLE
Update to aqbanking-6.2.10

### DIFF
--- a/gnucash.modules
+++ b/gnucash.modules
@@ -174,7 +174,7 @@
 
   <autotools id="aqbanking" autogen-sh="autoreconf" makeargs="-j1"
 	     autogenargs="--enable-local-install">
-    <branch module="366/aqbanking-6.2.9.tar.gz" repo="aqbanking" version="6.2.9" >
+    <branch module="368/aqbanking-6.2.10.tar.gz" repo="aqbanking" version="6.2.10">
     </branch>
     <dependencies>
       <dep package="gwenhywfar"/>


### PR DESCRIPTION
Fix wrong error message in PIN/TAN, see threads
https://lists.gnucash.org/pipermail/gnucash-de/2021-March/012076.html
and
https://lists.gnucash.org/pipermail/gnucash-de/2021-February/012027.html