### PR TITLE
Update to aqbanking-6.3.0

### DIFF
--- a/gnucash.modules
+++ b/gnucash.modules
@@ -174,7 +174,7 @@
 
   <autotools id="aqbanking" autogen-sh="autoreconf" makeargs="-j1"
 	     autogenargs="--enable-local-install">
-    <branch module="368/aqbanking-6.2.10.tar.gz" repo="aqbanking" version="6.2.10">
+    <branch module="372/aqbanking-6.3.0.tar.gz" repo="aqbanking" version="6.3.0">
     </branch>
     <dependencies>
       <dep package="gwenhywfar"/>


### PR DESCRIPTION
Log all jobs in $HOME/.aqbanking/jobs/
- independent from
-- logging or debugging settings,
-- the calling application.
- currently verbose for FinTS
- to easier retrace what happened to the respective orders