### PR TITLE
Add docbook-xsl (and docbook-xml) to build dependencies.

### DIFF
--- a/setup-mingw64.ps1
+++ b/setup-mingw64.ps1
@@ -268,7 +268,7 @@ $ignorefile = ""
 bash-command -command "perl -ibak -pe 'BEGIN{undef $/;} s#[[]options[]]\R(Include = [^\R]*\R)?#[options]\nInclude = /etc/pacman.d/gnucash-ignores.pacman\n#smg' /etc/pacman.conf"
 
 # Install the remaining dependencies.
-$deps = "boost icu gtk3 iso-codes shared-mime-info libmariadbclient libsoup libwebp postgresql ninja pdcurses sqlite3"
+$deps = "boost icu gtk3 iso-codes shared-mime-info libmariadbclient libsoup libwebp postgresql ninja pdcurses sqlite3 docbook-xsl"
 
 Write-Host @"
 


### PR DESCRIPTION
After GnuCash-docs PR 221, it is better to install Docbook XSL and DTD files.
This request is for adding dependencies.

https://github.com/Gnucash/gnucash-docs/pull/211#issue-719207228

If you have internet access, this patch is not necessary, but the build process consumes much time in order to download DTDs and XSLs.

Without docbook-xsl:
real    23m53.206s
user    0m0.000s
sys     0m0.015s

With docbook-xsl:
docbook-xsl
real    1m26.612s
user    0m0.000s
sys     0m0.000s
