### PR TITLE
Extend setup variables to include our version also in AppVersion

### DIFF
--- a/inno_setup/gnucash-mingw64.iss
+++ b/inno_setup/gnucash-mingw64.iss
@@ -8,6 +8,7 @@
 [Setup]
 ; Using the name here directly because we want it capitalized
 AppName=GnuCash
+AppVersion=@PACKAGE_VERSION@
 AppVerName=GnuCash @PACKAGE_VERSION@
 AppPublisher=GnuCash Development Team
 AppPublisherURL=http://www.gnucash.org


### PR DESCRIPTION
Some users pointed out that until now, a version checking tool called
WinGet is not able to find out the installed version of gnucash, as it is
looking for a registry key "DisplayVersion". This might be caused by not
setting the AppVersion value for the inno setup (and there is no other
variable to be found concerning version in inno), which is hence added here.
https://jrsoftware.org/ishelp/index.php?topic=setup_appversion

User report: https://lists.gnucash.org/pipermail/gnucash-de/2021-September/012199.html