### PR TITLE
Update to aqbanking-6.5.0 and gwenhywfar-5.9.0 

### DIFF
--- a/gnucash.modules
+++ b/gnucash.modules
@@ -143,7 +143,7 @@
 
   <autotools id="gwenhywfar" autogen-sh="configure"
              autogenargs="--with-guis='gtk3' --enable-local-install --disable-binreloc PKG_CONFIG='pkg-config --dont-define-prefix'">
-    <branch module="402/gwenhywfar-5.8.1.tar.gz" version="5.8.1"
+    <branch module="411/gwenhywfar-5.8.2.tar.gz" version="5.8.2"
             repo="aqbanking">
       <patch file="gwenhywfar-5.7.4-typemaker2-Makefiles.patch" strip="1"/>
     </branch>

--- a/gnucash.modules
+++ b/gnucash.modules
@@ -143,7 +143,7 @@
 
   <autotools id="gwenhywfar" autogen-sh="configure"
              autogenargs="--with-guis='gtk3' --enable-local-install --disable-binreloc PKG_CONFIG='pkg-config --dont-define-prefix'">
-    <branch module="396/gwenhywfar-5.7.4.tar.gz" version="5.7.4"
+    <branch module="402/gwenhywfar-5.8.1.tar.gz" version="5.8.1"
             repo="aqbanking">
       <patch file="gwenhywfar-5.7.4-typemaker2-Makefiles.patch" strip="1"/>
     </branch>
@@ -173,7 +173,7 @@
 
   <autotools id="aqbanking" autogen-sh="autoreconf" makeargs="-j1"
 	     autogenargs="--enable-local-install">
-    <branch module="394/aqbanking-6.4.0.tar.gz" repo="aqbanking" version="6.4.0">
+    <branch module="400/aqbanking-6.4.1.tar.gz" repo="aqbanking" version="6.4.1">
     </branch>
     <dependencies>
       <dep package="gwenhywfar"/>

--- a/gnucash.modules
+++ b/gnucash.modules
@@ -143,7 +143,7 @@
 
   <autotools id="gwenhywfar" autogen-sh="configure"
              autogenargs="--with-guis='gtk3' --enable-local-install --disable-binreloc PKG_CONFIG='pkg-config --dont-define-prefix'">
-    <branch module="411/gwenhywfar-5.8.2.tar.gz" version="5.8.2"
+    <branch module="415/gwenhywfar-5.9.0.tar.gz" version="5.9.0"
             repo="aqbanking">
       <patch file="gwenhywfar-5.7.4-typemaker2-Makefiles.patch" strip="1"/>
     </branch>
@@ -173,7 +173,7 @@
 
   <autotools id="aqbanking" autogen-sh="autoreconf" makeargs="-j1"
 	     autogenargs="--enable-local-install">
-    <branch module="400/aqbanking-6.4.1.tar.gz" repo="aqbanking" version="6.4.1">
+    <branch module="435/aqbanking-6.5.0.tar.gz" repo="aqbanking" version="6.5.0">
     </branch>
     <dependencies>
       <dep package="gwenhywfar"/>


### PR DESCRIPTION
I don't know, if gwenhywfar-5.7.4-typemaker2-Makefiles.patch is still required or went upstream. So I didnt touch that part.