### PR TITLE
Update to LibOFX 0.10.5

### DIFF
--- a/gnucash.modules
+++ b/gnucash.modules
@@ -214,8 +214,8 @@
   </autotools>
 
   <autotools id="libofx" autogen-sh='autoreconf'>
-    <branch repo="sourceforge" module="libofx/libofx-0.10.3.tar.gz"
-	    version="0.10.3">
+    <branch repo="sourceforge" module="libofx/libofx-0.10.5.tar.gz"
+	    version="0.10.5">
       <patch file="libofx-namespace-std.patch" strip="1"/>
       <patch file="libofx-build-once.patch" strip="1"/>
     </branch>


### PR DESCRIPTION
IMHO we can drop libofx-namespace-std.patch. Should be [libofx' commit 46888a](https://github.com/libofx/libofx/commit/46888affe907c1e5f91b68566c01cedb25948dfe) f