### PR TITLE
Update aqbanking to 6.5.12beta

### DIFF
--- a/gnucash.modules
+++ b/gnucash.modules
@@ -152,7 +152,7 @@
 
   <autotools id="aqbanking" autogen-sh="autoreconf" makeargs="-j1"
 	     autogenargs="--enable-local-install">
-    <branch module="499/aqbanking-6.5.4.tar.gz" repo="aqbanking" version="6.5.4">
+    <branch module="526/aqbanking-6.5.12beta.tar.gz" repo="aqbanking" version="6.5.12beta">
     </branch>
     <dependencies>
       <dep package="gwenhywfar"/>


### PR DESCRIPTION
should fix gnucash bug 798840 (see
https://bugs.gnucash.org/show_bug.cgi?id=798840)

aqgivve: add missing GWENHYWFAR_CB in functions (needed for Windows builds).
…